### PR TITLE
Fix cmd with spaces

### DIFF
--- a/simpleJack/simpleJackServer.py
+++ b/simpleJack/simpleJackServer.py
@@ -40,7 +40,7 @@ while(not isExit):
         cmd = ""
         data = ""
         try:
-                cmd, data = input.split(" ", 2)
+                cmd, data = input.split(" ", 1)
                 cmd = cmd.lower()
         except:
                 cmd = input


### PR DESCRIPTION
Fix to allow spaces in cmd such as `cmd dir c:\` for example.